### PR TITLE
Add OS detection script and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
-# workspace
+# OS Detection Script
+
+This project contains a simple shell script, `check_os.sh`, that identifies the operating system.
+
+## Usage
+
+```bash
+./check_os.sh
+```
+
+The script prints the detected OS such as `Detected Linux`, `Detected macOS`, or `Detected Windows`.
+
+## Requirements
+
+The script relies on the `uname` command, which is typically available on Unix-like systems. On Windows, run it from environments like Git Bash or WSL.
+

--- a/check_os.sh
+++ b/check_os.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+os_name="$(uname -s)"
+case "$os_name" in
+  Linux*) echo "Detected Linux" ;;
+  Darwin*) echo "Detected macOS" ;;
+  CYGWIN*|MINGW*|MSYS*) echo "Detected Windows" ;;
+  *) echo "Unknown OS: $os_name" ;;
+esac


### PR DESCRIPTION
## Summary
- add `check_os.sh` to detect Linux, macOS, or Windows using `uname`
- document script usage and requirements in README

## Testing
- `./check_os.sh`


------
https://chatgpt.com/codex/tasks/task_e_6895c34fa8708321acbb2cd9dac74fda