### PR TITLE
Add Playwright CLI for automated Google searches

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,40 @@
-# OS Detection Script
+# Google Search Playwright CLI
 
-This project contains a simple shell script, `check_os.sh`, that identifies the operating system.
+Ứng dụng dòng lệnh Python này sử dụng [Playwright](https://playwright.dev/python/) để tự động tìm kiếm Google, hỗ trợ chuyển trang tùy thuộc vào số lượng kết quả bạn muốn xem và hiển thị tiêu đề cùng mô tả cho mỗi kết quả.
 
-## Usage
+## Yêu cầu
+
+- Python 3.10 trở lên
+- Playwright và các trình duyệt của nó (`playwright install`)
+
+## Cài đặt
 
 ```bash
-./check_os.sh
+pip install .
+playwright install
 ```
 
-The script prints the detected OS such as `Detected Linux`, `Detected macOS`, or `Detected Windows`.
+## Sử dụng
 
-## Requirements
+Chạy ứng dụng thông qua script đã cài đặt:
 
-The script relies on the `uname` command, which is typically available on Unix-like systems. On Windows, run it from environments like Git Bash or WSL.
+```bash
+google-search-cli
+```
 
+Hoặc chạy trực tiếp module chính:
+
+```bash
+python -m main
+```
+
+Ứng dụng sẽ yêu cầu nhập từ khóa và số lượng kết quả muốn xem, sau đó tự động điều hướng qua các trang kết quả để thu thập dữ liệu.
+
+## Ghi chú
+
+- Việc tự động hóa Google có thể bị chặn nếu gửi quá nhiều yêu cầu trong thời gian ngắn.
+- Bạn có thể chỉnh sửa logic trích xuất trong `src/google_search/searcher.py` để phù hợp với thay đổi giao diện của Google.
+
+## Tiện ích bổ sung
+
+Kho chứa vẫn bao gồm script `check_os.sh` giúp nhận diện hệ điều hành hiện tại.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,13 @@
+[project]
+name = "google-search-playwright"
+version = "0.1.0"
+description = "Automated Google search CLI using Playwright"
+authors = [{name = "Example Author"}]
+readme = "README.md"
+requires-python = ">=3.10"
+dependencies = [
+    "playwright>=1.43.0",
+]
+
+[project.scripts]
+google-search-cli = "main:main"

--- a/src/google_search/__init__.py
+++ b/src/google_search/__init__.py
@@ -1,0 +1,6 @@
+"""Google search automation package."""
+
+from .models import SearchResult
+from .searcher import GoogleSearcher
+
+__all__ = ["GoogleSearcher", "SearchResult"]

--- a/src/google_search/models.py
+++ b/src/google_search/models.py
@@ -1,0 +1,11 @@
+"""Data models for Google search results."""
+
+from dataclasses import dataclass
+
+
+@dataclass
+class SearchResult:
+    """Represents a single search result entry."""
+
+    title: str
+    description: str

--- a/src/google_search/searcher.py
+++ b/src/google_search/searcher.py
@@ -1,0 +1,119 @@
+"""Utilities for automating Google searches using Playwright."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, List
+
+from playwright.sync_api import Browser, Page, Playwright, sync_playwright
+
+from .models import SearchResult
+
+
+@dataclass
+class SearchConfig:
+    """Configuration for Google search execution."""
+
+    keyword: str
+    total_results: int
+
+
+class GoogleSearcher:
+    """Performs Google searches and returns structured results."""
+
+    SEARCH_URL = "https://www.google.com/ncr"
+
+    def __init__(self, playwright: Playwright | None = None) -> None:
+        self._playwright = playwright
+        self._browser: Browser | None = None
+
+    def __enter__(self) -> "GoogleSearcher":
+        self.start()
+        return self
+
+    def __exit__(self, exc_type, exc, traceback) -> None:
+        self.stop()
+
+    def start(self) -> None:
+        """Starts the Playwright browser if it is not already running."""
+
+        if self._playwright is None:
+            self._playwright = sync_playwright().start()
+        if self._browser is None:
+            self._browser = self._playwright.chromium.launch(headless=True)
+
+    def stop(self) -> None:
+        """Closes the Playwright browser and stops Playwright."""
+
+        if self._browser is not None:
+            self._browser.close()
+            self._browser = None
+        if self._playwright is not None:
+            self._playwright.stop()
+            self._playwright = None
+
+    def search(self, config: SearchConfig) -> List[SearchResult]:
+        """Searches Google and returns a list of search results."""
+
+        if self._browser is None:
+            self.start()
+
+        assert self._browser is not None  # for type checkers
+
+        page = self._browser.new_page()
+        page.goto(self.SEARCH_URL)
+        self._accept_consent_if_present(page)
+        self._perform_search(page, config.keyword)
+
+        results: List[SearchResult] = []
+        while len(results) < config.total_results:
+            results.extend(self._collect_results(page))
+            if len(results) >= config.total_results:
+                break
+            if not self._go_to_next_page(page):
+                break
+
+        page.close()
+        return results[: config.total_results]
+
+    def _perform_search(self, page: Page, keyword: str) -> None:
+        search_box_selector = "textarea[name='q']"
+        page.fill(search_box_selector, keyword)
+        page.keyboard.press("Enter")
+        page.wait_for_selector("div#search")
+
+    def _collect_results(self, page: Page) -> List[SearchResult]:
+        result_elements = page.query_selector_all("div#search div.g")
+        results: List[SearchResult] = []
+        for element in result_elements:
+            title = element.query_selector("h3")
+            description = element.query_selector("div.VwiC3b")
+            if title is None or description is None:
+                continue
+            title_text = title.inner_text().strip()
+            description_text = description.inner_text().strip()
+            if title_text and description_text:
+                results.append(
+                    SearchResult(title=title_text, description=description_text)
+                )
+        return results
+
+    def _go_to_next_page(self, page: Page) -> bool:
+        next_button = page.query_selector("a#pnnext")
+        if next_button is None:
+            return False
+        next_button.click()
+        page.wait_for_load_state("networkidle")
+        return True
+
+    def _accept_consent_if_present(self, page: Page) -> None:
+        consent_button_selectors: Iterable[str] = (
+            "button#L2AGLb",
+            "form[action*='consent'] button",
+        )
+        for selector in consent_button_selectors:
+            button = page.query_selector(selector)
+            if button is not None:
+                button.click()
+                page.wait_for_load_state("networkidle")
+                break

--- a/src/main.py
+++ b/src/main.py
@@ -1,0 +1,45 @@
+"""Command line interface for the Google search automation tool."""
+
+from __future__ import annotations
+
+from typing import NoReturn
+
+from google_search import GoogleSearcher, SearchConfig
+
+
+def main() -> NoReturn:
+    """Prompts the user for input and displays Google search results."""
+
+    keyword = input("Nhập từ khóa cần tìm: ").strip()
+    if not keyword:
+        print("Từ khóa không được để trống.")
+        return
+
+    while True:
+        total_results_raw = input("Nhập số lượng kết quả muốn xem: ").strip()
+        try:
+            total_results = int(total_results_raw)
+        except ValueError:
+            print("Vui lòng nhập một số nguyên hợp lệ.")
+            continue
+        if total_results <= 0:
+            print("Số lượng kết quả phải lớn hơn 0.")
+            continue
+        break
+
+    with GoogleSearcher() as searcher:
+        search_config = SearchConfig(keyword=keyword, total_results=total_results)
+        results = searcher.search(search_config)
+
+    if not results:
+        print("Không tìm thấy kết quả phù hợp.")
+        return
+
+    for index, result in enumerate(results, start=1):
+        print(f"\nKết quả {index}:")
+        print(f"Tiêu đề: {result.title}")
+        print(f"Mô tả  : {result.description}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a Google search automation package built on Playwright
- provide a command-line interface that prompts for a keyword and desired result count
- document installation steps and project usage, including packaging metadata

## Testing
- not run (Playwright browsers are not installed in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68dcda74c9908321ad91fb1a96460568